### PR TITLE
Update file size error message to be relevant

### DIFF
--- a/webapp/src/main/java/gov/nist/healthcare/ttt/webapp/common/controller/CCDAR2ValidatorController.java
+++ b/webapp/src/main/java/gov/nist/healthcare/ttt/webapp/common/controller/CCDAR2ValidatorController.java
@@ -59,6 +59,9 @@ public class CCDAR2ValidatorController {
 	    		Path normalizedPath =  path.normalize();
 				String fileName = normalizedPath.toString();
 				File file = new File(fileName);
+				if(!TempUploadController.hasFileSize()) {
+					throw new TTTCustomException("0x0082", "Unknown file size");
+				}
 				if(TempUploadController.isValidFileSize()) {
 					throw new TTTCustomException("0x0070", "Attached files cannot be larger than 1MB");
 				}

--- a/webapp/src/main/java/gov/nist/healthcare/ttt/webapp/common/controller/CCDAR2ValidatorController.java
+++ b/webapp/src/main/java/gov/nist/healthcare/ttt/webapp/common/controller/CCDAR2ValidatorController.java
@@ -59,6 +59,9 @@ public class CCDAR2ValidatorController {
 	    		Path normalizedPath =  path.normalize();
 				String fileName = normalizedPath.toString();
 				File file = new File(fileName);
+				if(TempUploadController.isValidFileSize()) {
+					throw new TTTCustomException("0x0070", "Attached files cannot be larger than 1MB");
+				}
 				if(!file.exists() || fileName.startsWith("../") || !fileName.startsWith(tDir + File.separator)) {
 					throw new TTTCustomException("0x0050", "Action not supported by API.");
 				}

--- a/webapp/src/main/java/gov/nist/healthcare/ttt/webapp/common/controller/CCDAR3ValidatorController.java
+++ b/webapp/src/main/java/gov/nist/healthcare/ttt/webapp/common/controller/CCDAR3ValidatorController.java
@@ -62,7 +62,7 @@ public class CCDAR3ValidatorController {
 				String fileName = normalizedPath.toString();
 				File file = new File(fileName);
 				if(TempUploadController.isValidFileSize()) {
-					throw new TTTCustomException("0x0050", "Attached files cannot be larger than 1MB");
+					throw new TTTCustomException("0x0070", "Attached files cannot be larger than 1MB");
 				}
 				if(!file.exists() || fileName.startsWith("../") || !fileName.startsWith(tDir + File.separator)) {
 					throw new TTTCustomException("0x0050", "Action not supported by API.");

--- a/webapp/src/main/java/gov/nist/healthcare/ttt/webapp/common/controller/CCDAR3ValidatorController.java
+++ b/webapp/src/main/java/gov/nist/healthcare/ttt/webapp/common/controller/CCDAR3ValidatorController.java
@@ -61,9 +61,12 @@ public class CCDAR3ValidatorController {
 	    		Path normalizedPath =  path.normalize();				
 				String fileName = normalizedPath.toString();
 				File file = new File(fileName);
+				if(TempUploadController.isValidFileSize()) {
+					throw new TTTCustomException("0x0050", "Attached files cannot be larger than 1MB");
+				}
 				if(!file.exists() || fileName.startsWith("../") || !fileName.startsWith(tDir + File.separator)) {
 					throw new TTTCustomException("0x0050", "Action not supported by API.");
-				}								
+				}
 				HttpPost post = new HttpPost(mdhtUrl);
 				FileBody fileBody = new FileBody(file);
 				//

--- a/webapp/src/main/java/gov/nist/healthcare/ttt/webapp/common/controller/CCDAR3ValidatorController.java
+++ b/webapp/src/main/java/gov/nist/healthcare/ttt/webapp/common/controller/CCDAR3ValidatorController.java
@@ -61,6 +61,9 @@ public class CCDAR3ValidatorController {
 	    		Path normalizedPath =  path.normalize();				
 				String fileName = normalizedPath.toString();
 				File file = new File(fileName);
+				if(!TempUploadController.hasFileSize()) {
+					throw new TTTCustomException("0x0082", "Unknown file size");
+				}
 				if(TempUploadController.isValidFileSize()) {
 					throw new TTTCustomException("0x0070", "Attached files cannot be larger than 1MB");
 				}

--- a/webapp/src/main/java/gov/nist/healthcare/ttt/webapp/common/controller/SVAPValidatorCtrl.java
+++ b/webapp/src/main/java/gov/nist/healthcare/ttt/webapp/common/controller/SVAPValidatorCtrl.java
@@ -62,7 +62,7 @@ public class SVAPValidatorCtrl {
 				String fileName = normalizedPath.toString();
 				File file = new File(fileName);
 				if(TempUploadController.isValidFileSize()) {
-					throw new TTTCustomException("0x0050", "Attached files cannot be larger than 1MB");
+					throw new TTTCustomException("0x0070", "Attached files cannot be larger than 1MB");
 				}
 				if(!file.exists() || fileName.startsWith("../") || !fileName.startsWith(tDir + File.separator)) {
 					throw new TTTCustomException("0x0050", "Action not supported by API.");

--- a/webapp/src/main/java/gov/nist/healthcare/ttt/webapp/common/controller/SVAPValidatorCtrl.java
+++ b/webapp/src/main/java/gov/nist/healthcare/ttt/webapp/common/controller/SVAPValidatorCtrl.java
@@ -61,6 +61,9 @@ public class SVAPValidatorCtrl {
 	    		Path normalizedPath =  path.normalize();				
 				String fileName = normalizedPath.toString();
 				File file = new File(fileName);
+				if(TempUploadController.isValidFileSize()) {
+					throw new TTTCustomException("0x0050", "Attached files cannot be larger than 1MB");
+				}
 				if(!file.exists() || fileName.startsWith("../") || !fileName.startsWith(tDir + File.separator)) {
 					throw new TTTCustomException("0x0050", "Action not supported by API.");
 				}								

--- a/webapp/src/main/java/gov/nist/healthcare/ttt/webapp/common/controller/SVAPValidatorCtrl.java
+++ b/webapp/src/main/java/gov/nist/healthcare/ttt/webapp/common/controller/SVAPValidatorCtrl.java
@@ -61,6 +61,9 @@ public class SVAPValidatorCtrl {
 	    		Path normalizedPath =  path.normalize();				
 				String fileName = normalizedPath.toString();
 				File file = new File(fileName);
+				if(!TempUploadController.hasFileSize()) {
+					throw new TTTCustomException("0x0082", "Unknown file size");
+				}
 				if(TempUploadController.isValidFileSize()) {
 					throw new TTTCustomException("0x0070", "Attached files cannot be larger than 1MB");
 				}

--- a/webapp/src/main/java/gov/nist/healthcare/ttt/webapp/common/controller/TempUploadController.java
+++ b/webapp/src/main/java/gov/nist/healthcare/ttt/webapp/common/controller/TempUploadController.java
@@ -26,7 +26,8 @@ import java.util.UUID;
 
 public class TempUploadController {
 	
-	public static boolean exceededFileSizeLimit;
+	private static boolean exceededFileSizeLimit;
+	private static boolean fileSizeExists;
 	String tDir = System.getProperty("java.io.tmpdir");
 	private static Logger logger = LogManager.getLogger(TempUploadController.class.getName());
 	
@@ -38,6 +39,15 @@ public class TempUploadController {
 		fileInfo.setAttributes(request);
 		
 		exceededFileSizeLimit = false;
+		fileSizeExists = true;
+		
+		//Check file size exists
+		if(fileInfo.getFlowTotalSize() == null) {
+			logger.info("Unknown file size");
+			fileSizeExists = false;
+			return fileInfo;
+		}
+		
 		//Check file size
 		if(Integer.parseInt(fileInfo.getFlowTotalSize()) > 1000000) {
 			logger.info("File size exceeded, upload cancelled. Limit: 1000000 File size: " +fileInfo.getFlowTotalSize());
@@ -109,6 +119,10 @@ public class TempUploadController {
 	
 	public static boolean isValidFileSize() {
 		return exceededFileSizeLimit;
+	}
+	
+	public static boolean hasFileSize() {
+		return fileSizeExists;
 	}
 
 }


### PR DESCRIPTION
Previously error message stated: "Please verify the document does not contain in-line XSL styling and/or address the following error: Content is not allowed in prolog." when uploaded file was over 2MB. Now more appropriately displays: "Attached files cannot be larger than 1MB". Also prevented the file from being uploaded initially if the size exceeds the limit.