### PR TITLE
Update release_notes.txt

### DIFF
--- a/gui/src/assets/release_notes.txt
+++ b/gui/src/assets/release_notes.txt
@@ -1,3 +1,7 @@
+SITE release notes are now being tracked in a single location. Go to 
+https://github.com/onc-healthit/site-content/blob/master/ReleaseNotes.md
+to see release notes.
+
 ==Version 2.3.67#06/03/2024
     *1. ETT: Fix reference validator API call that broke scenario testing
 


### PR DESCRIPTION
Updated release notes to refer users to 
https://github.com/onc-healthit/site-content/blob/master/ReleaseNotes.md so we don't have to post release notes to two locations.